### PR TITLE
validate the address when APIService.GetAccount() is called.

### DIFF
--- a/rpc/api_service.go
+++ b/rpc/api_service.go
@@ -17,6 +17,7 @@ package rpc
 
 import (
 	"encoding/hex"
+	"strings"
 
 	"github.com/medibloc/go-medibloc/consensus/dpos"
 
@@ -49,6 +50,10 @@ func newAPIService(bm *core.BlockManager, tm *core.TransactionManager, ee *core.
 	}
 }
 
+func isValidAccount(account string) bool {
+	return len(account) == 66 && (strings.HasPrefix(account, "02") || strings.HasPrefix(account, "03"))
+}
+
 // GetAccount handles GetAccount rpc.
 func (s *APIService) GetAccount(ctx context.Context, req *rpcpb.GetAccountRequest) (*rpcpb.Account,
 	error) {
@@ -56,7 +61,7 @@ func (s *APIService) GetAccount(ctx context.Context, req *rpcpb.GetAccountReques
 	var err error
 
 	// XOR
-	if !(math.XOR(len(req.Address) != 66, req.Alias == "") && math.XOR(req.Type == "", req.Height == 0)) {
+	if !(math.XOR(isValidAccount(req.Address), req.Alias != "") && math.XOR(req.Type != "", req.Height != 0)) {
 		return nil, status.Error(codes.InvalidArgument, ErrMsgInvalidRequest)
 	}
 

--- a/rpc/api_service_test.go
+++ b/rpc/api_service_test.go
@@ -43,6 +43,18 @@ func TestAPIService_GetAccount(t *testing.T) {
 
 	e.GET("/v1/account").
 		WithQuery("type", "tail").
+		WithQuery("address", "0000").
+		Expect().
+		Status(http.StatusBadRequest)
+
+	e.GET("/v1/account").
+		WithQuery("type", "tail").
+		WithQuery("address", "000000000000000000000000000000000000000000000000000000000000000000").
+		Expect().
+		Status(http.StatusBadRequest)
+
+	e.GET("/v1/account").
+		WithQuery("type", "tail").
 		WithQuery("address", payer.Addr).
 		Expect().
 		Status(http.StatusOK).


### PR DESCRIPTION
According to secp256k1 spec, compressed public key should start with "02" or "03".